### PR TITLE
Fix login flow and supabase config

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,11 @@ cd <YOUR_PROJECT_NAME>
 # Step 3: Install the necessary dependencies.
 npm i
 
-# Step 4: Start the development server with auto-reloading and an instant preview.
+# Step 4: Create a `.env.local` file and add your Supabase credentials
+VITE_SUPABASE_URL=<your-supabase-url>
+VITE_SUPABASE_ANON_KEY=<your-anon-key>
+
+# Step 5: Start the development server with auto-reloading and an instant preview.
 npm run dev
 ```
 
@@ -59,6 +63,14 @@ This project is built with:
 - React
 - shadcn-ui
 - Tailwind CSS
+
+### Linting
+
+Install dependencies with `npm install` and then run:
+
+```sh
+npm run lint
+```
 
 ## How can I deploy this project?
 

--- a/src/components/auth/LoginForm.tsx
+++ b/src/components/auth/LoginForm.tsx
@@ -82,10 +82,10 @@ const LoginForm: React.FC<LoginFormProps> = ({
         }
         
         console.log('🔐 LoginForm: Starting login...');
-        // Perform login
-        await login(email, password);
+        // Perform login and wait for profile to be fetched
+        const loggedInProfile = await login(email, password);
         toast.success("Login erfolgreich!");
-        
+
         console.log("✅ LoginForm: Login successful, determining redirect...");
         
         // Determine if we need to redirect to an interview
@@ -117,8 +117,8 @@ const LoginForm: React.FC<LoginFormProps> = ({
           // Standard role-based redirect
           setTimeout(() => {
             // Get the role from the authenticated user's profile
-            const roleBasedPath = getRoleRedirectPath(profile?.role);
-            console.log("🏢 LoginForm: Navigating to role-based path:", { role: profile?.role, path: roleBasedPath });
+            const roleBasedPath = getRoleRedirectPath((loggedInProfile || profile)?.role);
+            console.log("🏢 LoginForm: Navigating to role-based path:", { role: (loggedInProfile || profile)?.role, path: roleBasedPath });
             navigate(roleBasedPath);
           }, 100);
         }

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -2,8 +2,8 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Database } from './types';
 
-const SUPABASE_URL = "https://gehhxwqlhzsesxzqleks.supabase.co";
-const SUPABASE_PUBLISHABLE_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImdlaGh4d3FsaHpzZXN4enFsZWtzIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDYxNzkxOTYsImV4cCI6MjA2MTc1NTE5Nn0.n0xnb83NgWgJFA1eZ6K_36N_JhePnmiEYnRS-vHEcWM";
+const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL!;
+const SUPABASE_PUBLISHABLE_KEY = import.meta.env.VITE_SUPABASE_ANON_KEY!;
 
 // Import the supabase client like this:
 // import { supabase } from "@/integrations/supabase/client";

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -5,7 +5,7 @@ import { ProfileForm } from '@/components/talent/ProfileForm';
 import { Button } from '@/components/ui/button';
 
 export default function Profile() {
-  const { user, isAuthenticated } = useAuth();
+  const { user, profile, isAuthenticated } = useAuth();
   
   // Redirect to login if not authenticated
   if (!isAuthenticated) {
@@ -13,7 +13,7 @@ export default function Profile() {
   }
   
   // Redirect to dashboard if not a talent (user role)
-  if (user?.role !== 'user') {
+  if (profile?.role !== 'user') {
     return <Navigate to="/dashboard" replace />;
   }
   


### PR DESCRIPTION
## Summary
- correct profile role check on profile page
- fetch user profile directly in `login` and update redirect logic
- load Supabase credentials from environment variables
- document `.env.local` and lint script in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683c41f60bc4832087a82e591d3b0031